### PR TITLE
deployment bug fix: typo in the templates folder name

### DIFF
--- a/ramp-frontend/setup.py
+++ b/ramp-frontend/setup.py
@@ -41,7 +41,7 @@ EXTRAS_REQUIRE = {
 }
 PACKAGE_DATA = {
     'ramp_frontend': [
-        os.path.join('template', '*'),
+        os.path.join('templates', '*'),
         os.path.join('static', 'css', 'style.css'),
         os.path.join('static', 'css', 'themes', 'flat-blue.css'),
         os.path.join('static', 'img', '*'),


### PR DESCRIPTION
This typo prevented a deployed ramp-frontend from running (ie. when not pip installed with -e .) 